### PR TITLE
Add small avatar and reduce code duplication

### DIFF
--- a/xenforo/library/bdApi/XenForo/Model/User.php
+++ b/xenforo/library/bdApi/XenForo/Model/User.php
@@ -95,18 +95,9 @@ class bdApi_XenForo_Model_User extends XFCP_bdApi_XenForo_Model_User
         $data['links'] = array(
             'permalink' => XenForo_Link::buildPublicLink('members', $user),
             'detail' => bdApi_Data_Helper_Core::safeBuildApiLink('users', $user),
-            'avatar' => XenForo_Template_Helper_Core::callHelper('avatar', array(
-                $user,
-                'm',
-                false,
-                true
-            )),
-            'avatar_big' => XenForo_Template_Helper_Core::callHelper('avatar', array(
-                $user,
-                'l',
-                false,
-                true
-            )),
+            'avatar_small' => $this->getAvatarLinkForUser($user, 's'),
+            'avatar' => $this->getAvatarLinkForUser($user, 'm'),
+            'avatar_big' => $this->getAvatarLinkForUser($user, 'l'),
             'followers' => bdApi_Data_Helper_Core::safeBuildApiLink('users/followers', $user),
             'followings' => bdApi_Data_Helper_Core::safeBuildApiLink('users/followings', $user),
         );
@@ -198,6 +189,16 @@ class bdApi_XenForo_Model_User extends XFCP_bdApi_XenForo_Model_User
         $choices[self::ORDER_USER_ID] = 'user.user_id';
 
         return parent::getOrderByClause($choices, $fetchOptions, $defaultOrderSql);
+    }
+
+    private function getAvatarLinkForUser($user, $size)
+    {
+        return XenForo_Template_Helper_Core::callHelper('avatar', array(
+                $user,
+                $size,
+                false,
+                true
+            ));
     }
 
 }


### PR DESCRIPTION
This adds an `avatar_small` link to the user API data. It also consolidates how avatar links are retrieved.
