### PR TITLE
fix: server error on GET /users/find

### DIFF
--- a/xenforo/library/bdApi/ControllerApi/User.php
+++ b/xenforo/library/bdApi/ControllerApi/User.php
@@ -74,7 +74,13 @@ class bdApi_ControllerApi_User extends bdApi_ControllerApi_Abstract
                 && $session->checkScope(bdApi_Model_OAuth2::SCOPE_MANAGE_SYSTEM)
             ) {
                 // perform email search only if visitor is an admin and granted admincp scope
-                $user = $this->_getUserModel()->getUserByEmail($email);
+                $user = $this->_getUserModel()->getUserByEmail(
+                    $email,
+                    array(
+                        'join'            => XenForo_Model_User::FETCH_USER_PRIVACY,
+                        'followingUserId' => XenForo_Visitor::getUserId(),
+                    )
+                );
                 if (!empty($user)) {
                     $users[$user['user_id']] = $user;
                 }
@@ -85,7 +91,11 @@ class bdApi_ControllerApi_User extends bdApi_ControllerApi_Abstract
             // perform username search only if nothing found and username is long enough
             $users = $this->_getUserModel()->getUsers(
                 array('username' => array($username, 'r')),
-                array('limit' => 10)
+                array(
+                    'limit'           => 10,
+                    'join'            => XenForo_Model_User::FETCH_USER_PRIVACY,
+                    'followingUserId' => XenForo_Visitor::getUserId(),
+                )
             );
         }
 

--- a/xenforo/library/bdApi/ControllerApi/User.php
+++ b/xenforo/library/bdApi/ControllerApi/User.php
@@ -76,10 +76,7 @@ class bdApi_ControllerApi_User extends bdApi_ControllerApi_Abstract
                 // perform email search only if visitor is an admin and granted admincp scope
                 $user = $this->_getUserModel()->getUserByEmail(
                     $email,
-                    array(
-                        'join'            => XenForo_Model_User::FETCH_USER_PRIVACY,
-                        'followingUserId' => XenForo_Visitor::getUserId(),
-                    )
+                    $this->_getUserModel()->getFetchOptionsToPrepareApiData()
                 );
                 if (!empty($user)) {
                     $users[$user['user_id']] = $user;
@@ -91,10 +88,10 @@ class bdApi_ControllerApi_User extends bdApi_ControllerApi_Abstract
             // perform username search only if nothing found and username is long enough
             $users = $this->_getUserModel()->getUsers(
                 array('username' => array($username, 'r')),
-                array(
-                    'limit'           => 10,
-                    'join'            => XenForo_Model_User::FETCH_USER_PRIVACY,
-                    'followingUserId' => XenForo_Visitor::getUserId(),
+                $this->_getUserModel()->getFetchOptionsToPrepareApiData(
+                    array(
+                        'limit' => 10,
+                    )
                 )
             );
         }


### PR DESCRIPTION
When requesting the endpoint `GET /users/find` the API responded with
an error:

```
{"errors":["A server error occurred. Please try again later."],"system_info":{"visitor_id":2,"time":1457090816}}
```

XenForo throws an exception: **Missing following state for user ID 2 in user 3**. The stacktrace reads as follows:

```
#0 /home/vagrant/xenforo_sandbox/library/XenForo/Model/UserProfile.php(180): XenForo_Model_User->passesPrivacyCheck(NULL, Array, Array)
#1 /home/vagrant/xenforo_sandbox/library/bdApi/XenForo/Model/User.php(216): XenForo_Model_UserProfile->canPostOnProfile(Array)
#2 /home/vagrant/xenforo_sandbox/library/bdApi/XenForo/Model/User.php(31): bdApi_XenForo_Model_User->prepareApiDataForUser(Array)
#3 /home/vagrant/xenforo_sandbox/library/bdApi/ControllerApi/User.php(93): bdApi_XenForo_Model_User->prepareApiDataForUsers(Array)
#4 /home/vagrant/xenforo_sandbox/library/XenForo/FrontController.php(351): bdApi_ControllerApi_User->actionGetFind()
#5 /home/vagrant/xenforo_sandbox/library/XenForo/FrontController.php(134): XenForo_FrontController->dispatch(Object(XenForo_RouteMatch))
#6 /home/vagrant/xenforo_sandbox/api/index.php(58): XenForo_FrontController->run()
#7 {main}
```

After fixing this, another exception was thrown: **Undefined index: allow_post_profile**:

```
#0 /home/vagrant/xenforo_sandbox/library/XenForo/Model/UserProfile.php(180): XenForo_Application::handlePhpError(8, 'Undefined index...', '/home/vagrant/C...', 180, Array)
#1 /home/vagrant/xenforo_sandbox/library/bdApi/XenForo/Model/User.php(216): XenForo_Model_UserProfile->canPostOnProfile(Array)
#2 /home/vagrant/xenforo_sandbox/library/bdApi/XenForo/Model/User.php(31): bdApi_XenForo_Model_User->prepareApiDataForUser(Array)
#3 /home/vagrant/xenforo_sandbox/library/bdApi/ControllerApi/User.php(97): bdApi_XenForo_Model_User->prepareApiDataForUsers(Array)
#4 /home/vagrant/xenforo_sandbox/library/XenForo/FrontController.php(351): bdApi_ControllerApi_User->actionGetFind()
#5 /home/vagrant/xenforo_sandbox/library/XenForo/FrontController.php(134): XenForo_FrontController->dispatch(Object(XenForo_RouteMatch))
#6 /home/vagrant/xenforo_sandbox/api/index.php(58): XenForo_FrontController->run()
#7 {main}
```

The reason for this are missing keys in the `$user` array(s) that are
fetched in `bdApi_ControllerApi_User::actionGetFind()`.

This pull request provides a fix for this issue. The needed array keys for
privacy settings and follower status are loaded now into the user
array(s).
