### PR TITLE
Added support for thread prefixes

### DIFF
--- a/docs/api.markdown
+++ b/docs/api.markdown
@@ -280,6 +280,21 @@ Detail information of a category.
             forum_thread_count: (int),
             forum_post_count: (int),
             forum_is_follow: (boolean), # since forum-2014053001
+            forum_prefixes: { # since forum-2016031001
+                {
+                    group_title: (string),
+                    group_prefixes: [
+                        {
+                            prefix_id: (int),
+                            prefix_title: (string)
+                        },
+                        ...
+                    ]
+                },
+                ...
+            },
+            thread_default_prefix_id: (int), # since forum-2016031001
+            thread_prefix_is_required: (boolean), # since forum-2016031001
             links: {
                 permalink: (uri),
                 detail: (uri),
@@ -535,6 +550,7 @@ Parameters:
  * `forum_id` (__required__): id of the target forum.
  * `thread_title` (__required__): title of the new thread.
  * `post_body` (__required__): content of the new thread.
+ * `thread_prefix_id` (_optional_): id of a prefix for the new thread. Since forum-2016031001.
  * `thread_tags` (_optional_): thread tags for the new thread. Since forum-2015091002.
 
 Required scopes:
@@ -597,6 +613,13 @@ Detail information of a thread.
             thread_is_followed: (boolean), # since forum-2014052903
             first_post: (post),
             last_post: (post), # must be in fields_include to work, since forum-2015121801
+            thread_prefixes: [ # since forum-2016031001
+                {
+                    prefix_id: (int),
+                    prefix_title: (string)
+                },
+                ...
+            ],
             poll: { # since forum-2015100601
                 poll_id: (int),
                 poll_question: (string),
@@ -1007,8 +1030,9 @@ Edit a post.
 Parameters:
 
  * `post_body` (__required__): new content of the post.
- * `thread_title` (_optional_, since forum-2014052203): new title of the thread (only used if the post is the first post in the thread and the user can edit thread).
- * `thread_tags` (_optional_, since forum-2015091101): new tags of the thread (only used if the post is the first post in the thread and the user can edit thread tags).
+ * `thread_title` (_optional_, since forum-2014052203): new title of the thread (only used if the post is the first post in the thread and the authenticated user can edit thread).
+ * `thread_prefix_id` (_optional_, since forum-2016031001): new id of the thread's prefix (only used if the post is the first post in the thread and the authenticated user can edit thread).
+ * `thread_tags` (_optional_, since forum-2015091101): new tags of the thread (only used if the post is the first post in the thread and the authenticated user can edit thread tags).
 
 Required scopes:
 

--- a/xenforo/library/bdApi/ControllerApi/Index.php
+++ b/xenforo/library/bdApi/ControllerApi/Index.php
@@ -55,7 +55,7 @@ class bdApi_ControllerApi_Index extends bdApi_ControllerApi_Abstract
     protected function _getModules()
     {
         $modules = array(
-            'forum' => 2015121802,
+            'forum' => 2016031001,
             'oauth2' => 2016030902,
             'subscription' => 2014092301,
         );

--- a/xenforo/library/bdApi/Extend/Model/Thread.php
+++ b/xenforo/library/bdApi/Extend/Model/Thread.php
@@ -87,6 +87,13 @@ class bdApi_Extend_Model_Thread extends XFCP_bdApi_Extend_Model_Thread
             $data['first_post'] = $postModel->prepareApiDataForPost($firstPost, $thread, $forum);
         }
 
+        $data['thread_prefixes'] = array();
+        if (!empty($thread['prefix_id'])) {
+            /** @var bdApi_Extend_Model_ThreadPrefix $prefixModel */
+            $prefixModel = $this->getModelFromCache('XenForo_Model_ThreadPrefix');
+            $data['thread_prefixes'][] = $prefixModel->prepareApiDataForPrefix($thread);
+        }
+
         if ($thread['discussion_type'] === 'poll'
             && isset($this->_bdApi_polls[$thread['thread_id']])
         ) {

--- a/xenforo/library/bdApi/Extend/Model/ThreadPrefix.php
+++ b/xenforo/library/bdApi/Extend/Model/ThreadPrefix.php
@@ -1,0 +1,76 @@
+<?php
+
+class bdApi_Extend_Model_ThreadPrefix extends XFCP_bdApi_Extend_Model_ThreadPrefix
+{
+    public function bdApi_getUsablePrefixesByForums($nodeIds, array $viewingUser = null)
+    {
+        $this->standardizeViewingUserReference($viewingUser);
+
+        $prefixes = $this->getPrefixesInForums($nodeIds);
+
+        $prefixesByForum = array();
+        foreach ($prefixes AS $prefix) {
+            if (!$this->_verifyPrefixIsUsableInternal($prefix, $viewingUser)) {
+                continue;
+            }
+
+            $prefixId = $prefix['prefix_id'];
+            $forumId = $prefix['node_id'];
+            $prefixGroupId = $prefix['prefix_group_id'];
+
+            if (!isset($prefixesByForum[$forumId])) {
+                $prefixesByForum[$forumId] = array();
+            }
+
+            if (!isset($prefixesByForum[$forumId][$prefixGroupId])) {
+                $prefixesByForum[$forumId][$prefixGroupId] = array();
+            }
+
+            $prefixesByForum[$forumId][$prefixGroupId]['prefixes'][$prefixId] = $prefix;
+        }
+
+        return $prefixesByForum;
+    }
+
+    public function prepareApiDataForPrefixes(array $prefixes)
+    {
+        $data = array();
+
+        foreach ($prefixes as $prefixId => $prefix) {
+            if (isset($prefix['prefix_id'])) {
+                // this is a prefix
+                $data[] = $this->prepareApiDataForPrefix($prefix);
+            } elseif (isset($prefix['prefixes'])) {
+                // this is a group
+                $groupPrefixes = array();
+                foreach ($prefix['prefixes'] as $_prefix) {
+                    $groupPrefixes[] = $this->prepareApiDataForPrefix($_prefix);
+                }
+
+                $data[] = array(
+                    'group_title' => $prefixId > 0
+                        ? new XenForo_Phrase($this->getPrefixGroupTitlePhraseName($prefixId))
+                        : new XenForo_Phrase('ungrouped'),
+                    'group_prefixes' => $groupPrefixes,
+                );
+            }
+        }
+
+        return $data;
+    }
+
+    public function prepareApiDataForPrefix(array $prefix)
+    {
+        $publicKeys = array(
+            // xf_thread_prefix
+            'prefix_id' => 'prefix_id',
+        );
+
+        $data = bdApi_Data_Helper_Core::filter($prefix, $publicKeys);
+
+        $data['prefix_title'] = new XenForo_Phrase($this->getPrefixTitlePhraseName($prefix['prefix_id']));
+
+        return $data;
+    }
+
+}

--- a/xenforo/library/bdApi/Listener.php
+++ b/xenforo/library/bdApi/Listener.php
@@ -46,6 +46,7 @@ class bdApi_Listener
             'XenForo_Model_Search',
             'XenForo_Model_Tag',
             'XenForo_Model_Thread',
+            'XenForo_Model_ThreadPrefix',
             'XenForo_Model_ThreadWatch',
             'XenForo_Model_UserIgnore',
 


### PR DESCRIPTION
Included:
- Data for forum: `forum_prefixes`, `thread_default_prefix_id` and `thread_prefix_is_required`
- Data for thread: `thread_prefixes`
- POST `/threads` now supports one optional parameter `thread_prefix_id`
- PUT `/threads` now supports one optional parameter `thread_prefix_id`
