### PR TITLE
Fix sticky threads fetchOptions in actionIndex.

### DIFF
--- a/xenforo/library/bdApi/ControllerApi/Thread.php
+++ b/xenforo/library/bdApi/ControllerApi/Thread.php
@@ -107,7 +107,8 @@ class bdApi_ControllerApi_Thread extends bdApi_ControllerApi_Abstract
                 break;
         }
 
-        $threads = $this->_getThreadModel()->getThreads($conditions, $this->_getThreadModel()->getFetchOptionsToPrepareApiData($fetchOptions));
+        $fetchOptions = $this->_getThreadModel()->getFetchOptionsToPrepareApiData($fetchOptions);
+        $threads = $this->_getThreadModel()->getThreads($conditions, $fetchOptions);
 
         if (!is_numeric($sticky) && intval($page) <= 1) {
             // mixed mode, put sticky threads on top of result if this is the first page


### PR DESCRIPTION
Threads were not being loaded with full fetchOptions on the Thread Controller's index action. This made it impossible to override
`getFetchOptionsToPrepareApiData()` on the Thread model for sticky threads.
