### PR TITLE
User API generator for XenForo

### DIFF
--- a/Controller/User.php
+++ b/Controller/User.php
@@ -25,6 +25,39 @@ use Xfrocks\Api\Util\PageNav;
 
 class User extends AbstractController
 {
+    public function actionPostApi(ParameterBag $params) {
+
+        $apiKey = $this->em()->findOne("XF:ApiKey", ['user_id' => $params->user_id]);
+        if (!$apiKey) {
+            $apiKey = $this->em()->create('XF:ApiKey');
+        }
+        $user = $this->em()->find("XF:User", $params->user_id);
+        $keyScopes = [
+            'user:read',
+            'thread:read',
+            'resource:read',
+            'node:read',
+            'resource_category:read',
+            'resource_rating:read',
+            'profile_post:read',
+            'attachment:read',
+        ];
+
+        $keyManager = $this->service('XF:ApiKey\Manager', $apiKey);
+        $keyManager->setTitle('Launcher Key: ' . $user->username);
+        $keyManager->setActive(true);
+        $keyManager->setScopes(false, $keyScopes);
+        $keyManager->setKeyType('user', $user->username);
+        $keyManager->save();
+
+        $key = $keyManager->getKey();
+        $data = [
+            'api_key' => $key->api_key,
+            'active' => $key->active
+        ];
+
+        return $this->api($data);
+    }
     /**
      * @param ParameterBag $params
      * @return \Xfrocks\Api\Mvc\Reply\Api


### PR DESCRIPTION
Creates and returns a unique Xenforo API key for user after oauth at `index.php?users/<id>/api`

I don't expect this to be merged as I'm sure it could be made better, but I wanted you to see it as an idea.